### PR TITLE
Feature add number validation

### DIFF
--- a/main.c
+++ b/main.c
@@ -6,7 +6,7 @@
 
 enum VERSION_RESULT
 {
-    FAIL = -1,
+    //FAIL = -1,
     LEFT = 1,
     RIGHT = 2,
     EQUAL = 3
@@ -25,10 +25,11 @@ int version_parse(VERSION *pVer, char *str);
 bool validate_version_string(char *str);
 void version_print(VERSION *pVer);
 void version_compare_print(VERSION *pL, VERSION *pR);
+bool consecutive_chars(char *const str, char c);
 
-int main() {
-    char ver_string[] = {'5','.','2','5','.','5','.','0','\0'}; // CANNOT use read-only memory due to strtok
-    char ver_string2[] = {'5','.','5','.','5','.','1','\0'};
+int main(void) {
+    char ver_string[] = {'5','.','5','.','5','.','0','\0'}; // CANNOT use read-only memory due to strtok
+    char ver_string2[] = {'5','.','1','.','5','.','1','\0'};
     VERSION *ver = version_new(ver_string);
     VERSION *ver2 = version_new(ver_string2);
     version_compare_print(ver, ver2);
@@ -65,6 +66,7 @@ int version_parse(VERSION *pVer, char * str)
     }
     char *token;
     char *delim = ".";
+
     token = strtok(str, delim);
     pVer->major = (unsigned int) atoi(token);
     token = strtok(NULL, delim);
@@ -73,6 +75,8 @@ int version_parse(VERSION *pVer, char * str)
     pVer->build = (unsigned int) atoi(token);
     token = strtok(NULL, delim);
     pVer->revision = (unsigned int) atoi(token);
+
+    return 0;
 
 }
 
@@ -88,6 +92,7 @@ bool validate_version_string(char *str)
         if(tmp == '.') ++count;
         if((tmp > '9' || tmp < '0') && tmp != '.') return false;
     }
+    if(consecutive_chars(str, '.')) return false;
     if(count == 3) return true;
     return false;
 }
@@ -149,4 +154,27 @@ void version_compare_print(VERSION *pL, VERSION *pR)
             fprintf(stderr, "An error occurred in the version compare function.\n");
     }
     return;
+}
+
+/*
+ * Does str have consecutive c?
+ */
+bool consecutive_chars(char *const str, char c)
+{
+    assert(str);
+    unsigned char consecutive;
+    size_t i, len = strlen(str);
+
+    for(i = 0; i < len; ++i)
+    {
+        if(i > 0 && str[i] == c)
+        {
+            if(str[i-1] == str[i]) return true;
+        }
+        if((i + 1) < len && str[i] == c)
+        {
+            if(str[i+1] == str[i]) return true;
+        }
+    }
+    return false;
 }

--- a/main.c
+++ b/main.c
@@ -19,14 +19,16 @@ typedef struct _version
     unsigned int build;
     unsigned int revision;
 } VERSION;
+
 VERSION *version_new(char *str);
 int version_parse(VERSION *pVer, char *str);
 bool validate_version_string(char *str);
 void version_print(VERSION *pVer);
 void version_compare_print(VERSION *pL, VERSION *pR);
+
 int main() {
-    char ver_string[] = {'5','.','5','.','5','.','0','\0'}; // CANNOT use read-only memory due to strtok
-    char ver_string2[] = {'5','.','5','.','5','.','0','\0'};
+    char ver_string[] = {'5','.','2','5','.','5','.','0','\0'}; // CANNOT use read-only memory due to strtok
+    char ver_string2[] = {'5','.','5','.','5','.','1','\0'};
     VERSION *ver = version_new(ver_string);
     VERSION *ver2 = version_new(ver_string2);
     version_compare_print(ver, ver2);
@@ -34,7 +36,7 @@ int main() {
     free(ver2);
     ver = NULL;
     ver2 = NULL;
-    return 0;
+    return EXIT_SUCCESS;
 }
 
 VERSION *version_new(char *str)
@@ -58,7 +60,7 @@ int version_parse(VERSION *pVer, char * str)
     assert(pVer && str);
     if(!validate_version_string(str))
     {
-        fprintf(stderr, "Invalid version #. Format xxx.xxx.xxx.xxx");
+        fprintf(stderr, "Invalid version #. Format xxx.xxx.xxx.xxx\n");
         return -1;
     }
     char *token;
@@ -84,6 +86,7 @@ bool validate_version_string(char *str)
     {
         tmp = *copy;
         if(tmp == '.') ++count;
+        if((tmp > '9' || tmp < '0') && tmp != '.') return false;
     }
     if(count == 3) return true;
     return false;


### PR DESCRIPTION
Added validation checks to ensure that the version string provided to the API doesn't contain any characters other than 0-9 and the '.' delimiter. Delimiter also cannot appear more than 1 time in a row.